### PR TITLE
Align instructions for new registry entries

### DIFF
--- a/registry/alternative-schema.md
+++ b/registry/alternative-schema.md
@@ -13,7 +13,7 @@ parent: Registries
 
 ## Contributing
 
-Please raise a [Pull-Request](https://github.com/OAI/spec.openapis.org/pulls) or [Issue](https://github.com/OAI/OpenAPI-Specification/issues) to contribute or discuss a registry value.
+Please open an [Issue](https://github.com/OAI/OpenAPI-Specification/issues) to discuss a registry value.
 
 ## Values
 

--- a/registry/draft-feature.md
+++ b/registry/draft-feature.md
@@ -13,7 +13,7 @@ parent: Registries
 
 ## Contributing
 
-Please raise a [Pull-Request](https://github.com/OAI/spec.openapis.org/pulls) or [Issue](https://github.com/OAI/OpenAPI-Specification/issues) to contribute or discuss a registry value.
+Please open an [Issue](https://github.com/OAI/OpenAPI-Specification/issues) to discuss a registry value.
 
 ## Values
 

--- a/registry/format.md
+++ b/registry/format.md
@@ -17,7 +17,7 @@ The registry SHOULD NOT contain two entries that have the same meaning, unless a
 
 ## Contributing
 
-Please raise a [Pull-Request](https://github.com/OAI/spec.openapis.org/pulls) or [Issue](https://github.com/OAI/OpenAPI-Specification/issues) to contribute or discuss a registry value.
+Please raise a [Pull-Request](https://github.com/OAI/spec.openapis.org/pulls) against the `main` branch and add a new Markdown file to the folder `registries/_format`. The name of the file is considered the registration entry, ignoring the file extension. Alternatively you can open an [Issue](https://github.com/OAI/OpenAPI-Specification/issues) to discuss a registry value.
 
 ## Values
 

--- a/registry/tag-kind.md
+++ b/registry/tag-kind.md
@@ -13,7 +13,7 @@ The `kind` addition to OpenAPI tags is planned for release in OpenAPI 3.2, so su
 
 ## Contributing
 
-Please raise a [Pull-Request](https://github.com/OAI/spec.openapis.org/pulls) or [Issue](https://github.com/OAI/OpenAPI-Specification/issues) to contribute or discuss a registry value.
+Please raise a [Pull-Request](https://github.com/OAI/spec.openapis.org/pulls) against the `main` branch and add a new Markdown file to the folder `registries/_tag-kind`. The name of the file is considered the registration entry, ignoring the file extension. Alternatively you can open an [Issue](https://github.com/OAI/OpenAPI-Specification/issues) to discuss a registry value.
 
 ## Values
 


### PR DESCRIPTION
Use the more detailed text from the index page where we expect contributions, and only suggest a new issue for rarely used registries.