### PR TITLE
adds unixtime as a format to the registry

### DIFF
--- a/registries/_format/unixtime.md
+++ b/registries/_format/unixtime.md
@@ -9,7 +9,7 @@ source: https://pubs.opengroup.org/onlinepubs/9799919799/
 ---
 
 {% capture summary %}
-The `{{page.slug}}` format represents seconds since Jan 1st 1970 - defined as 4.19 Seconds Since the Epoch - [IEEE1003.1-2024/POSIX.1-2024](https://pubs.opengroup.org/onlinepubs/9799919799/). This format entry is to ensure future versions of OpenAPI maintain compatibility with [OpenAPI 3.0.x](https://spec.openapis.org/oas/v3.0.0).
+The `{{page.slug}}` format represents seconds since Jan 1st 1970 - defined as 4.19 Seconds Since the Epoch - [IEEE1003.1-2024/POSIX.1-2024](https://pubs.opengroup.org/onlinepubs/9799919799/).
 {% endcapture %}
 
 {% include format-entry.md summary=summary %}


### PR DESCRIPTION
This pull request adds the unixtime as a format to the registry.

# Q&A

## Why IEEE reference?

I couldn't find any better normative definition as an RFC. And the alternative is a linux man page as far as I understand.

## Why this name?

It's true that the registry has "somewhat used a kebab casing convention by default". However [this format is already used in the wild](https://github.com/search?q=%28language%3AOASv3-yaml+OR+language%3AOASv3-json%29+unixtime+&type=code) and has existed under that name with a clear "convention" for a looonng time now. So my assumption here is that it's safe to define in our registry to enable better interop of existing descriptions.

## Why no unixtime ms and nano?

I don't have an immediate need for it, but should somebody need it in the future they can always introduce unixtime-milli and unixtime-nano in the future.

## Why both string and number as a base type?

To overcome some parsers inability to deserialize large numbers, we've done that for a number (pun intended) of numeric types already in the registry.

## Why no precision about whether it's 32 or 64 bits?

Because the common usage in the wild is also ambiguous about that. Essentially we'll run out of unixtime 32 bits in Jan 19th 2038, so most systems accept an int64 nowadays as well to overcome that limitation.