### PR TITLE
Register x-oai-traits

### DIFF
--- a/_includes/extension-entry.md
+++ b/_includes/extension-entry.md
@@ -8,7 +8,7 @@
 ### Schema
 
 ```yaml
-{{page.schema}}
+{{page.schema|jsonify}}
 ```
 
 ### Example

--- a/registries/_extension/x-oai-traits.md
+++ b/registries/_extension/x-oai-traits.md
@@ -1,0 +1,22 @@
+---
+owner: ralfhandl
+issue:
+description: Identify in an OpenAPI Description where Overlay updates should be applied.
+schema:
+  type: array
+  items:
+    type: string
+layout: default
+---
+
+{% capture summary %}
+The `x-oai-traits` extension is used identify places in an OpenAPI Description where Overlay updates should be applied. Its value is an array of strings, each string identifying a feature that an Overlay should apply.
+{% endcapture %}
+
+{% capture example %}
+See:
+
+* [Traits Example in Overlay Specification](https://spec.openapis.org/overlay/v1.0.0.html#traits-example)
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}  

--- a/registries/_extension/x-oai-traits.md
+++ b/registries/_extension/x-oai-traits.md
@@ -10,7 +10,7 @@ layout: default
 ---
 
 {% capture summary %}
-The `x-oai-traits` extension is used identify places in an OpenAPI Description where Overlay updates should be applied. Its value is an array of strings, each string identifying a feature that an Overlay should apply.
+The `x-oai-traits` extension is used to identify places in an OpenAPI Description where Overlay updates should be applied. Its value is an array of strings, each string identifying a feature that an Overlay should apply.
 {% endcapture %}
 
 {% capture example %}


### PR DESCRIPTION
The Overlay Specification uses a specification `x-oai-traits` to identify where overlay updates should be applied.

Use JSON to represent an extension's schema instead of Jekyll's default Ruby notation.