### PR TITLE
CODEOWNERS: do not add everyone for registry entry changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,9 @@
 # Repo
 * @oai/tsc @OAI/arazzo-maintainers @OAI/openapi-maintainers @OAI/overlay-maintainers
 
+# Registries
+/registries/ @OAI/tsc
+
 # Specifications
 /arazzo/ @OAI/tsc @OAI/arazzo-maintainers
 /oas/ @OAI/tsc @OAI/openapi-maintainers


### PR DESCRIPTION
Only suggest the TSC as default reviewers for registry entries, other teams/people can be added as needed.