### PR TITLE
Fix: #37. x-jsonld keywords.

### DIFF
--- a/registries/_extension/x-jsonld-context.md
+++ b/registries/_extension/x-jsonld-context.md
@@ -27,7 +27,7 @@ This extension is defined in [draft-polli-restapi-ld-keywords](https://datatrack
 
 {% capture example %}
 ```yaml
-openapi: 3.0.0
+openapi: 3.2.0
 ...
 components:
   schemas:

--- a/registries/_extension/x-jsonld-context.md
+++ b/registries/_extension/x-jsonld-context.md
@@ -1,0 +1,54 @@
+---
+owner: ioggstream
+issue:
+description: Used to associate a JSON-LD context to a schema, enabling semantic interpretation of JSON data.
+schema:
+  oneOf:
+    - type: string
+      format: uri
+    - type: object
+    - type: array
+      items:
+        oneOf:
+          - type: string
+            format: uri
+          - type: object
+objects: [ "schemaObject" ]
+layout: default
+---
+
+{% capture summary %}
+The `x-jsonld-context` extension is used to associate a JSON-LD `@context` to a schema, enabling semantic interpretation of JSON data by mapping terms to IRIs and defining the vocabulary. It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+It can be used in conjunction with `x-jsonld-type`.
+
+This extension is defined in [draft-polli-restapi-ld-keywords](https://datatracker.ietf.org/doc/draft-polli-restapi-ld-keywords/) and is based on the [JSON-LD 1.1](https://www.w3.org/TR/json-ld11/#interpreting-json-as-json-ld) specification.
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.0.0
+...
+components:
+  schemas:
+    Person:
+      "x-jsonld-context":
+        "@vocab": "https://schema.org/"
+      type: object
+      properties:
+        familyName: { type: string, maxLength: 255  }
+        givenName:  { type: string, maxLength: 255  }
+      example:
+        familyName: "Doe"
+        givenName: "John"
+```
+
+Used by: (informational)
+
+* Italian Agencies
+* https://schema.gov.it
+* https://api.gov.it
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}  
+

--- a/registries/_extension/x-jsonld-type.md
+++ b/registries/_extension/x-jsonld-type.md
@@ -39,7 +39,7 @@ components:
         givenName: "John"
 ```
 
-Used by:
+Used by: (informational)
 
 * Italian Agencies
 * https://schema.gov.it

--- a/registries/_extension/x-jsonld-type.md
+++ b/registries/_extension/x-jsonld-type.md
@@ -22,7 +22,7 @@ This extension is defined in [draft-polli-restapi-ld-keywords](https://datatrack
 
 {% capture example %}
 ```yaml
-openapi: 3.0.0
+openapi: 3.2.0
 ...
 components:
   schemas:

--- a/registries/_extension/x-jsonld-type.md
+++ b/registries/_extension/x-jsonld-type.md
@@ -1,0 +1,50 @@
+---
+owner: ioggstream
+issue:
+description: Used to associate a JSON-LD type to a schema, enabling semantic interoperability.
+schema:
+  oneOf:
+    - type: string
+    - type: array
+      items:
+        type: string
+objects: [ "schemaObject" ]
+layout: default
+---
+
+{% capture summary %}
+The `x-jsonld-type` extension is used to associate a JSON-LD `@type` to a schema, enabling semantic interoperability by specifying the type of the resource in terms of ontologies and vocabularies. It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+It can be used in conjunction with `x-jsonld-context`.
+
+This extension is defined in [draft-polli-restapi-ld-keywords](https://datatracker.ietf.org/doc/draft-polli-restapi-ld-keywords/) and is based on the [JSON-LD 1.1](https://www.w3.org/TR/json-ld11/#interpreting-json-as-json-ld) specification.
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.0.0
+...
+components:
+  schemas:
+    Person:
+      "x-jsonld-type": "https://schema.org/Person"
+      "x-jsonld-context":
+        "@vocab": "https://schema.org/"
+      type: object
+      properties:
+        familyName: { type: string, maxLength: 255  }
+        givenName:  { type: string, maxLength: 255  }
+      example:
+        familyName: "Doe"
+        givenName: "John"
+```
+
+Used by:
+
+* Italian Agencies
+* https://schema.gov.it
+* https://api.gov.it
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}  
+


### PR DESCRIPTION
## This PR

- adds x-jsonld-type and x-jsonld-context Extensions to OAS 3.0
- these extensions are used to attach semantic information to OpenAPI 3.0 Schema Objects.
- fix https://github.com/OAI/spec.openapis.org/issues/37

## Notes

- [x] I successfully built the pages on docker.