### PR TITLE
Register x-oai specification extensions for OpenAPI 3.2 down-leveling

### DIFF
--- a/registries/_extension/x-oai-additionalOperations.md
+++ b/registries/_extension/x-oai-additionalOperations.md
@@ -1,0 +1,52 @@
+---
+owner: mikekistler
+issue:
+description: Represents non-standard HTTP method operations on a Path Item when targeting OpenAPI versions prior to 3.2.
+schema:
+  type: object
+  additionalProperties:
+    $ref: "#/$defs/operationObject"
+objects: [ "pathItemObject" ]
+layout: default
+---
+
+{% capture summary %}
+The `x-oai-additionalOperations` extension represents HTTP method operations that are not part of the standard set defined by the target OpenAPI version. For example, the HTTP QUERY method is not a standard operation in OpenAPI 3.0 or 3.1, so it is serialized under this extension.
+
+In OpenAPI 3.2, this becomes the native `additionalOperations` field on Path Item Objects.
+
+Each key in the object is an HTTP method name (e.g. `QUERY`) and the value is an Operation Object.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.1.0
+info:
+  title: My API
+  version: 1.0.0
+paths:
+  /search:
+    x-oai-additionalOperations:
+      QUERY:
+        summary: Search with a request body
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  q:
+                    type: string
+        responses:
+          "200":
+            description: Search results
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}

--- a/registries/_extension/x-oai-additionalOperations.md
+++ b/registries/_extension/x-oai-additionalOperations.md
@@ -6,7 +6,7 @@ schema:
   type: object
   additionalProperties:
     $ref: "#/$defs/operationObject"
-objects: [ "pathItemObject" ]
+objects: [ "Path Item Object" ]
 layout: default
 ---
 

--- a/registries/_extension/x-oai-additionalOperations.md
+++ b/registries/_extension/x-oai-additionalOperations.md
@@ -11,9 +11,9 @@ layout: default
 ---
 
 {% capture summary %}
-The `x-oai-additionalOperations` extension represents HTTP method operations that are not part of the standard set defined by the target OpenAPI version. For example, the HTTP QUERY method is not a standard operation in OpenAPI 3.0 or 3.1, so it is serialized under this extension.
+OpenAPI 3.2 introduced the `additionalOperations` field on Path Item Objects to represent operations for HTTP methods that are not part of the standard set defined by the Path Item Object of the target OpenAPI version. For example, the non-standard `POLL` method has no standard operation in OpenAPI 3.2, so it can be represented as an entry in the `additionalOperations` field.
 
-In OpenAPI 3.2, this becomes the native `additionalOperations` field on Path Item Objects.
+The `x-oai-additionalOperations` extension brings this same capability to OpenAPI versions prior to 3.2, allowing you to represent operations for HTTP methods that are not part of the standard set defined by the Path Item Object of the target OpenAPI version. For example, the HTTP QUERY method has no standard operation in OpenAPI 3.0 or 3.1, so it can be represented as an entry in the `x-oai-additionalOperations` extension.
 
 Each key in the object is an HTTP method name (e.g. `QUERY`) and the value is an Operation Object.
 

--- a/registries/_extension/x-oai-deprecated.md
+++ b/registries/_extension/x-oai-deprecated.md
@@ -1,0 +1,37 @@
+---
+owner: mikekistler
+issue:
+description: Indicates that a Security Scheme is deprecated, used when targeting OpenAPI versions prior to 3.2.
+schema:
+  type: boolean
+objects: [ "securitySchemeObject" ]
+layout: default
+---
+
+{% capture summary %}
+The `x-oai-deprecated` extension indicates that a Security Scheme Object is deprecated and SHOULD be transitioned out of usage. In OpenAPI 3.2, this becomes the native `deprecated` field on Security Scheme Objects.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.1.0
+info:
+  title: My API
+  version: 1.0.0
+components:
+  securitySchemes:
+    legacyApiKey:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      x-oai-deprecated: true
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}

--- a/registries/_extension/x-oai-deprecated.md
+++ b/registries/_extension/x-oai-deprecated.md
@@ -4,7 +4,7 @@ issue:
 description: Indicates that a Security Scheme is deprecated, used when targeting OpenAPI versions prior to 3.2.
 schema:
   type: boolean
-objects: [ "securitySchemeObject" ]
+objects: [ "Security Scheme Object" ]
 layout: default
 ---
 

--- a/registries/_extension/x-oai-deprecated.md
+++ b/registries/_extension/x-oai-deprecated.md
@@ -9,7 +9,9 @@ layout: default
 ---
 
 {% capture summary %}
-The `x-oai-deprecated` extension indicates that a Security Scheme Object is deprecated and SHOULD be transitioned out of usage. In OpenAPI 3.2, this becomes the native `deprecated` field on Security Scheme Objects.
+OpenAPI 3.2 introduced the `deprecated` field on Security Scheme Objects to indicate that a security scheme is deprecated and SHOULD be transitioned out of usage.
+
+The `x-oai-deprecated` extension brings this same capability to OpenAPI versions prior to 3.2, allowing you to indicate that a Security Scheme Object is deprecated and SHOULD be transitioned out of usage.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 

--- a/registries/_extension/x-oai-deviceAuthorizationUrl.md
+++ b/registries/_extension/x-oai-deviceAuthorizationUrl.md
@@ -1,0 +1,41 @@
+---
+owner: mikekistler
+issue:
+description: The device authorization URL for an OAuth2 flow (RFC 8628), used when targeting OpenAPI versions prior to 3.2.
+schema:
+  type: string
+  format: uri
+objects: [ "oauthFlowObject" ]
+layout: default
+---
+
+{% capture summary %}
+The `x-oai-deviceAuthorizationUrl` extension specifies the URL to be used for device authorization as defined in [RFC 8628](https://www.rfc-editor.org/rfc/rfc8628). In OpenAPI 3.2, this becomes the native `deviceAuthorizationUrl` field on OAuth Flow Objects.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.1.0
+info:
+  title: My API
+  version: 1.0.0
+components:
+  securitySchemes:
+    oauth2:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://auth.example.com/token
+          x-oai-deviceAuthorizationUrl: https://auth.example.com/device
+          scopes:
+            read: Read access
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}

--- a/registries/_extension/x-oai-deviceAuthorizationUrl.md
+++ b/registries/_extension/x-oai-deviceAuthorizationUrl.md
@@ -10,7 +10,9 @@ layout: default
 ---
 
 {% capture summary %}
-The `x-oai-deviceAuthorizationUrl` extension specifies the URL to be used for device authorization as defined in [RFC 8628](https://www.rfc-editor.org/rfc/rfc8628). In OpenAPI 3.2, this becomes the native `deviceAuthorizationUrl` field on OAuth Flow Objects.
+OpenAPI 3.2 introduced the `deviceAuthorizationUrl` field on OAuth Flow Objects to specify the URL to be used for device authorization as defined in [RFC 8628](https://www.rfc-editor.org/rfc/rfc8628).
+
+The `x-oai-deviceAuthorizationUrl` extension brings this same capability to OpenAPI versions prior to 3.2, allowing you to specify the device authorization URL for an OAuth2 flow.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 

--- a/registries/_extension/x-oai-deviceAuthorizationUrl.md
+++ b/registries/_extension/x-oai-deviceAuthorizationUrl.md
@@ -5,7 +5,7 @@ description: The device authorization URL for an OAuth2 flow (RFC 8628), used wh
 schema:
   type: string
   format: uri
-objects: [ "oauthFlowObject" ]
+objects: [ "OAuth Flow Object" ]
 layout: default
 ---
 

--- a/registries/_extension/x-oai-itemEncoding.md
+++ b/registries/_extension/x-oai-itemEncoding.md
@@ -1,0 +1,46 @@
+---
+owner: mikekistler
+issue:
+description: Encoding properties for individual items in a multipart request part, used when targeting OpenAPI versions prior to 3.2.
+schema:
+  $ref: "#/$defs/encodingObject"
+objects: [ "mediaTypeObject" ]
+layout: default
+---
+
+{% capture summary %}
+The `x-oai-itemEncoding` extension defines the encoding for individual items within a media type, applicable to multipart or array-based content. In OpenAPI 3.2, this becomes the native `itemEncoding` field on Media Type Objects.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.1.0
+info:
+  title: My API
+  version: 1.0.0
+paths:
+  /upload:
+    post:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: array
+              items:
+                type: string
+                format: binary
+            x-oai-itemEncoding:
+              contentType: application/octet-stream
+      responses:
+        "200":
+          description: Upload successful
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}

--- a/registries/_extension/x-oai-itemEncoding.md
+++ b/registries/_extension/x-oai-itemEncoding.md
@@ -4,7 +4,7 @@ issue:
 description: Encoding properties for individual items in a multipart request part, used when targeting OpenAPI versions prior to 3.2.
 schema:
   $ref: "#/$defs/encodingObject"
-objects: [ "mediaTypeObject" ]
+objects: [ "mediaTypeObject", "encodingObject" ]
 layout: default
 ---
 

--- a/registries/_extension/x-oai-itemEncoding.md
+++ b/registries/_extension/x-oai-itemEncoding.md
@@ -9,7 +9,9 @@ layout: default
 ---
 
 {% capture summary %}
-The `x-oai-itemEncoding` extension defines the encoding for individual items within a media type, applicable to multipart or array-based content. In OpenAPI 3.2, this becomes the native `itemEncoding` field on Media Type Objects.
+OpenAPI 3.2 introduced the `itemEncoding` field on Media Type Objects to define the encoding for individual items within a media type, applicable to multipart or array-based content.
+
+The `x-oai-itemEncoding` extension brings this same capability to OpenAPI versions prior to 3.2, allowing you to define the encoding for individual items within a media type.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 

--- a/registries/_extension/x-oai-itemEncoding.md
+++ b/registries/_extension/x-oai-itemEncoding.md
@@ -4,7 +4,7 @@ issue:
 description: Encoding properties for individual items in a multipart request part, used when targeting OpenAPI versions prior to 3.2.
 schema:
   $ref: "#/$defs/encodingObject"
-objects: [ "mediaTypeObject", "encodingObject" ]
+objects: [ "Media Type Object", "Encoding Object" ]
 layout: default
 ---
 

--- a/registries/_extension/x-oai-itemSchema.md
+++ b/registries/_extension/x-oai-itemSchema.md
@@ -1,0 +1,47 @@
+---
+owner: mikekistler
+issue:
+description: Schema for individual items in a multipart request part, used when targeting OpenAPI versions prior to 3.2.
+schema:
+  $ref: "#/$defs/schemaObject"
+objects: [ "mediaTypeObject" ]
+layout: default
+---
+
+{% capture summary %}
+The `x-oai-itemSchema` extension defines the schema for individual items within a media type, applicable to multipart or array-based content. In OpenAPI 3.2, this becomes the native `itemSchema` field on Media Type Objects.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.1.0
+info:
+  title: My API
+  version: 1.0.0
+paths:
+  /upload:
+    post:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: array
+              items:
+                type: string
+                format: binary
+            x-oai-itemSchema:
+              type: string
+              format: binary
+      responses:
+        "200":
+          description: Upload successful
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}

--- a/registries/_extension/x-oai-itemSchema.md
+++ b/registries/_extension/x-oai-itemSchema.md
@@ -4,7 +4,7 @@ issue:
 description: Schema for individual items in a multipart request part, used when targeting OpenAPI versions prior to 3.2.
 schema:
   $ref: "#/$defs/schemaObject"
-objects: [ "mediaTypeObject" ]
+objects: [ "Media Type Object" ]
 layout: default
 ---
 

--- a/registries/_extension/x-oai-itemSchema.md
+++ b/registries/_extension/x-oai-itemSchema.md
@@ -9,7 +9,9 @@ layout: default
 ---
 
 {% capture summary %}
-The `x-oai-itemSchema` extension defines the schema for individual items within a media type, applicable to multipart or array-based content. In OpenAPI 3.2, this becomes the native `itemSchema` field on Media Type Objects.
+OpenAPI 3.2 introduced the `itemSchema` field on Media Type Objects to define the schema for individual items within a media type, applicable to multipart or array-based content.
+
+The `x-oai-itemSchema` extension brings this same capability to OpenAPI versions prior to 3.2, allowing you to define the schema for individual items within a media type.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 

--- a/registries/_extension/x-oai-name.md
+++ b/registries/_extension/x-oai-name.md
@@ -1,0 +1,37 @@
+---
+owner: mikekistler
+issue:
+description: An identifier for a Server Object, used when targeting OpenAPI versions prior to 3.2.
+schema:
+  type: string
+objects: [ "serverObject" ]
+layout: default
+---
+
+{% capture summary %}
+The `x-oai-name` extension provides a unique identifier for a Server Object. In OpenAPI 3.2, this becomes the native `name` field on Server Objects.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.1.0
+info:
+  title: My API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+    x-oai-name: production
+    description: Production server
+  - url: https://staging.example.com
+    x-oai-name: staging
+    description: Staging server
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}

--- a/registries/_extension/x-oai-name.md
+++ b/registries/_extension/x-oai-name.md
@@ -4,7 +4,7 @@ issue:
 description: An identifier for a Server Object, used when targeting OpenAPI versions prior to 3.2.
 schema:
   type: string
-objects: [ "serverObject" ]
+objects: [ "Server Object" ]
 layout: default
 ---
 

--- a/registries/_extension/x-oai-name.md
+++ b/registries/_extension/x-oai-name.md
@@ -9,7 +9,9 @@ layout: default
 ---
 
 {% capture summary %}
-The `x-oai-name` extension provides a unique identifier for a Server Object. In OpenAPI 3.2, this becomes the native `name` field on Server Objects.
+OpenAPI 3.2 introduced the `name` field on Server Objects to provide a unique identifier for a server.
+
+The `x-oai-name` extension brings this same capability to OpenAPI versions prior to 3.2, allowing you to provide a unique identifier for a Server Object.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 

--- a/registries/_extension/x-oai-prefixEncoding.md
+++ b/registries/_extension/x-oai-prefixEncoding.md
@@ -1,0 +1,48 @@
+---
+owner: mikekistler
+issue:
+description: Encoding properties applied before the item encoding in a multipart request part, used when targeting OpenAPI versions prior to 3.2.
+schema:
+  type: array
+  items:
+    $ref: "#/$defs/encodingObject"
+objects: [ "mediaTypeObject" ]
+layout: default
+---
+
+{% capture summary %}
+The `x-oai-prefixEncoding` extension defines an ordered list of encodings applied before the item encoding within a media type. In OpenAPI 3.2, this becomes the native `prefixEncoding` field on Media Type Objects.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.1.0
+info:
+  title: My API
+  version: 1.0.0
+paths:
+  /upload:
+    post:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: array
+              items:
+                type: string
+                format: binary
+            x-oai-prefixEncoding:
+              - contentType: application/json
+      responses:
+        "200":
+          description: Upload successful
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}

--- a/registries/_extension/x-oai-prefixEncoding.md
+++ b/registries/_extension/x-oai-prefixEncoding.md
@@ -6,7 +6,7 @@ schema:
   type: array
   items:
     $ref: "#/$defs/encodingObject"
-objects: [ "mediaTypeObject" ]
+objects: [ "Media Type Object" ]
 layout: default
 ---
 

--- a/registries/_extension/x-oai-prefixEncoding.md
+++ b/registries/_extension/x-oai-prefixEncoding.md
@@ -11,7 +11,9 @@ layout: default
 ---
 
 {% capture summary %}
-The `x-oai-prefixEncoding` extension defines an ordered list of encodings applied before the item encoding within a media type. In OpenAPI 3.2, this becomes the native `prefixEncoding` field on Media Type Objects.
+OpenAPI 3.2 introduced the `prefixEncoding` field on Media Type Objects to define an ordered list of encodings applied before the item encoding within a media type.
+
+The `x-oai-prefixEncoding` extension brings this same capability to OpenAPI versions prior to 3.2, allowing you to define an ordered list of encodings applied before the item encoding.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 


### PR DESCRIPTION
This PR registers seven `x-oai-*` specification extensions that are produced by the [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) library when serializing OpenAPI 3.2 features to OpenAPI 3.0 or 3.1 documents. These extensions allow round-tripping of 3.2 fields through older spec versions.

## Extensions added

| Extension | Object | 3.2 native field |
|-----------|--------|-------------------|
| `x-oai-additionalOperations` | Path Item | `additionalOperations` |
| `x-oai-name` | Server | `name` |
| `x-oai-deprecated` | Security Scheme | `deprecated` |
| `x-oai-itemSchema` | Media Type | `itemSchema` |
| `x-oai-itemEncoding` | Media Type | `itemEncoding` |
| `x-oai-prefixEncoding` | Media Type | `prefixEncoding` |
| `x-oai-deviceAuthorizationUrl` | OAuth Flow | `deviceAuthorizationUrl` |

All fall under the existing [`oai` namespace](https://spec.openapis.org/registry/namespace/oai.html) which is reserved for uses defined by the OpenAPI Initiative.

## Context

The Microsoft.OpenApi library uses the pattern of serializing OpenAPI 3.2 fields as `x-oai-*` extensions when the target version is 3.0 or 3.1. This enables tooling to preserve these values during round-trip processing even when the document uses an older OpenAPI version.

Source: https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Models/OpenApiPathItem.cs (and related model files)