### PR TITLE
Add language tag format to registry

### DIFF
--- a/registries/_format/language.md
+++ b/registries/_format/language.md
@@ -1,0 +1,15 @@
+---
+owner: timvdlippe
+issue: 
+description: language tag as defined in [RFC5646](https://www.rfc-editor.org/info/rfc5646/#section-2.1)
+base_type: string
+layout: default
+source: https://www.rfc-editor.org/info/rfc5646/#section-2.1
+source_label: RFC5646
+---
+
+{% capture summary %}
+The `{{page.slug}}` format represents a language as defined by Language-Tag - [RFC5646](https://www.rfc-editor.org/info/rfc5646/#section-2.1).
+{% endcapture %}
+
+{% include format-entry.md summary=summary %}


### PR DESCRIPTION
RFC5646 [1] defines a standardized format for language tags. This RFC is included in the more commonly known BCP47 [2].

[1]: https://www.rfc-editor.org/info/rfc5646/
[2]: https://www.rfc-editor.org/info/bcp47/