### PR TITLE
Add IPv4 and IPv6 CIDR format specifications

### DIFF
--- a/registries/_format/ipv4-cidr.md
+++ b/registries/_format/ipv4-cidr.md
@@ -1,0 +1,19 @@
+---
+owner: ChihweiLHBird
+issue:
+description: An IPv4 address in CIDR notation
+base_type: string
+layout: default
+source_label: RFC 4632
+source: https://www.rfc-editor.org/rfc/rfc4632#section-3.1
+---
+
+{% capture summary %}
+The `{{page.slug}}` format represents an IPv4 address in CIDR notation, with the address and prefix-length syntax described in [RFC4632](https://www.rfc-editor.org/rfc/rfc4632#section-3.1).
+
+The address MUST be a valid `ipv4` address, and the prefix length MUST be a decimal integer from `0` to `32`, inclusive. A plain IPv4 address without a prefix length is not accepted.
+
+Examples of valid values include `10.0.0.0/8` and `192.168.1.0/24`.
+{% endcapture %}
+
+{% include format-entry.md summary=summary %}

--- a/registries/_format/ipv6-cidr.md
+++ b/registries/_format/ipv6-cidr.md
@@ -1,0 +1,19 @@
+---
+owner: ChihweiLHBird
+issue:
+description: An IPv6 address in CIDR-style notation
+base_type: string
+layout: default
+source_label: RFC 4291
+source: https://www.rfc-editor.org/rfc/rfc4291#section-2.3
+---
+
+{% capture summary %}
+The `{{page.slug}}` format represents an IPv6 address in CIDR notation, with the syntax described in [RFC4291](https://www.rfc-editor.org/rfc/rfc4291#section-2.3).
+
+The address MUST be a valid `ipv6` address, and the prefix length MUST be a decimal integer from `0` to `128`, inclusive. A plain IPv6 address without a prefix length is not accepted.
+
+Examples of valid values include `2001:db8::/32` and `::1/128`.
+{% endcapture %}
+
+{% include format-entry.md summary=summary %}


### PR DESCRIPTION
Resolve #32 

### Summary

Adds two entries to the [Format Registry](https://spec.openapis.org/registry/format):

- `ipv4-cidr`, an IPv4 address in CIDR notation
- `ipv6-cidr`, an IPv6 address in CIDR-style notation

As discussed there, the existing `ipv4`/`ipv6` formats can't accept a prefix length without breaking current users (and they follow JSON Schema's address-only, dotted-quad semantics). This proposal adds a separate format per type.

### What's added

| Format | Base type | Value | Source |
|---|---|---|---|
| `ipv4-cidr` | `string` | a valid `ipv4` address + `/` + prefix length `0`–`32` | [RFC 4632 §3.1](https://www.rfc-editor.org/rfc/rfc4632#section-3.1) |
| `ipv6-cidr` | `string` | a valid `ipv6` address + `/` + prefix length `0`–`128` | [RFC 4291 §2.3](https://www.rfc-editor.org/rfc/rfc4291#section-2.3) |

Valid examples: `10.0.0.0/8`, `192.168.1.0/24`, `2001:db8::/32`, `::1/128`.
