### PR TITLE
docs: add x-jsonschema-unevaluatedProperties extension page

### DIFF
--- a/registries/_extension/x-jsonschema-unevaluatedProperties.md
+++ b/registries/_extension/x-jsonschema-unevaluatedProperties.md
@@ -1,5 +1,5 @@
 ---
-owner: mikekistler
+owner: baywet
 issue:
 description: The JSON Schema unevaluatedProperties keyword, used when targeting OpenAPI versions that do not directly support it.
 schema:

--- a/registries/_extension/x-jsonschema-unevaluatedProperties.md
+++ b/registries/_extension/x-jsonschema-unevaluatedProperties.md
@@ -11,7 +11,11 @@ layout: default
 ---
 
 {% capture summary %}
+JSON Schema 2019-09 introduced the [`unevaluatedProperties`](https://json-schema.org/draft/2019-09/json-schema-core#unevaluatedProperties) keyword to apply a schema to object properties not already evaluated by adjacent keywords.
+
 The `x-jsonschema-unevaluatedProperties` extension mirrors the JSON Schema `unevaluatedProperties` keyword by serializing it as `x-jsonschema-unevaluatedProperties` when targeting OpenAPI versions where `unevaluatedProperties` is not directly available.
+
+Use this extension only with JSON Schema versions before 2019-09; 2019-09 and later define `unevaluatedProperties` directly.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 

--- a/registries/_extension/x-jsonschema-unevaluatedProperties.md
+++ b/registries/_extension/x-jsonschema-unevaluatedProperties.md
@@ -29,13 +29,21 @@ info:
 paths: {}
 components:
   schemas:
-    User:
+    ExtensibleResource:
+      type: object
+      patternProperties:
+        ^x-: true
+
+    Invoice:
       type: object
       allOf:
-        - type: object
-          properties:
-            id:
-              type: string
+        - $ref: '#/components/schemas/ExtensibleResource'
+      properties:
+        id:
+          type: string
+        total:
+          type: number
+          format: double
       x-jsonschema-unevaluatedProperties: false
 ```
 {% endcapture %}

--- a/registries/_extension/x-jsonschema-unevaluatedProperties.md
+++ b/registries/_extension/x-jsonschema-unevaluatedProperties.md
@@ -1,0 +1,43 @@
+---
+owner: mikekistler
+issue:
+description: The JSON Schema unevaluatedProperties keyword, used when targeting OpenAPI versions that do not directly support it.
+schema:
+  oneOf:
+    - type: boolean
+    - $ref: "#/$defs/schemaObject"
+objects: [ "Schema Object" ]
+layout: default
+---
+
+{% capture summary %}
+The `x-jsonschema-unevaluatedProperties` extension mirrors the JSON Schema `unevaluatedProperties` keyword by serializing it as `x-jsonschema-unevaluatedProperties` when targeting OpenAPI versions where `unevaluatedProperties` is not directly available.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.0.4
+info:
+  title: My API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    User:
+      type: object
+      allOf:
+        - type: object
+          properties:
+            id:
+              type: string
+      x-jsonschema-unevaluatedProperties: false
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}


### PR DESCRIPTION
Adds the registry page for `x-jsonschema-patternProperties`.

OpenAPI.NET evidence:
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Models/OpenApiSchema.cs exposes `OpenApiSchema.PatternProperties`.
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs maps `OpenApiConstants.PatternPropertiesExtension` into `OpenApiSchema.PatternProperties`.