### PR TITLE
docs: add x-jsonschema-contentEncoding extension page

### DIFF
--- a/registries/_extension/x-jsonschema-contentEncoding.md
+++ b/registries/_extension/x-jsonschema-contentEncoding.md
@@ -1,5 +1,5 @@
 ---
-owner: mikekistler
+owner: baywet
 issue:
 description: The JSON Schema contentEncoding annotation, used when targeting OpenAPI versions that do not directly support it.
 schema:

--- a/registries/_extension/x-jsonschema-contentEncoding.md
+++ b/registries/_extension/x-jsonschema-contentEncoding.md
@@ -1,0 +1,38 @@
+---
+owner: mikekistler
+issue:
+description: The JSON Schema contentEncoding annotation, used when targeting OpenAPI versions that do not directly support it.
+schema:
+  type: string
+objects: [ "Schema Object" ]
+layout: default
+---
+
+{% capture summary %}
+JSON Schema defines the `contentEncoding` annotation to describe how a string value is encoded.
+
+The `x-jsonschema-contentEncoding` extension mirrors this JSON Schema keyword when targeting OpenAPI versions where the keyword is not directly available, serializing it as `x-jsonschema-contentEncoding`.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.0.4
+info:
+  title: My API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    ImageData:
+      type: string
+      x-jsonschema-contentEncoding: base64
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}


### PR DESCRIPTION
Adds one OpenAPI extension registry page for a JSON Schema compatibility extension.

Evidence from OpenAPI.NET:
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs