### PR TITLE
docs: add x-jsonschema-patternProperties extension page

### DIFF
--- a/registries/_extension/x-jsonschema-patternProperties.md
+++ b/registries/_extension/x-jsonschema-patternProperties.md
@@ -1,5 +1,5 @@
 ---
-owner: mikekistler
+owner: baywet
 issue:
 description: A map of regular expressions to schemas for matching property names, used when targeting OpenAPI versions that do not directly support patternProperties.
 schema:

--- a/registries/_extension/x-jsonschema-patternProperties.md
+++ b/registries/_extension/x-jsonschema-patternProperties.md
@@ -1,0 +1,40 @@
+---
+owner: mikekistler
+issue:
+description: A map of regular expressions to schemas for matching property names, used when targeting OpenAPI versions that do not directly support patternProperties.
+schema:
+  type: object
+  additionalProperties:
+    $ref: "#/$defs/schemaObject"
+objects: [ "Schema Object" ]
+layout: default
+---
+
+{% capture summary %}
+The `x-jsonschema-patternProperties` extension mirrors the JSON Schema `patternProperties` keyword by serializing it as `x-jsonschema-patternProperties` when targeting OpenAPI versions where `patternProperties` is not directly available.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.0.4
+info:
+  title: My API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    User:
+      type: object
+      x-jsonschema-patternProperties:
+        "^S_":
+          type: string
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}

--- a/registries/_extension/x-jsonschema-patternProperties.md
+++ b/registries/_extension/x-jsonschema-patternProperties.md
@@ -11,7 +11,11 @@ layout: default
 ---
 
 {% capture summary %}
+JSON Schema draft-03 introduced the [`patternProperties`](https://json-schema.org/draft-03/draft-zyp-json-schema-03.pdf#page=8) keyword to map regular expressions to schemas for matching property names.
+
 The `x-jsonschema-patternProperties` extension mirrors the JSON Schema `patternProperties` keyword by serializing it as `x-jsonschema-patternProperties` when targeting OpenAPI versions where `patternProperties` is not directly available.
+
+Use this extension only with JSON Schema versions before draft-03; draft-03 and later define `patternProperties` directly.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 


### PR DESCRIPTION
Adds the registry page for `x-jsonschema-unevaluatedProperties`.

OpenAPI.NET evidence:
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Models/OpenApiSchema.cs exposes `OpenApiSchema.UnevaluatedProperties` and `OpenApiSchema.UnevaluatedPropertiesSchema`.
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs maps `OpenApiConstants.UnevaluatedPropertiesExtension` into those schema properties.