### PR TITLE
docs: add x-jsonschema-contentSchema extension page

### DIFF
--- a/registries/_extension/x-jsonschema-contentSchema.md
+++ b/registries/_extension/x-jsonschema-contentSchema.md
@@ -1,5 +1,5 @@
 ---
-owner: mikekistler
+owner: baywet
 issue:
 description: The JSON Schema contentSchema subschema for decoded string content, used when targeting OpenAPI versions that do not directly support it.
 schema:

--- a/registries/_extension/x-jsonschema-contentSchema.md
+++ b/registries/_extension/x-jsonschema-contentSchema.md
@@ -1,0 +1,46 @@
+---
+owner: mikekistler
+issue:
+description: The JSON Schema contentSchema subschema for decoded string content, used when targeting OpenAPI versions that do not directly support it.
+schema:
+  $ref: "#/$defs/schemaObject"
+objects: [ "Schema Object" ]
+layout: default
+---
+
+{% capture summary %}
+JSON Schema defines the `contentSchema` keyword to describe the schema for decoded string content.
+
+The `x-jsonschema-contentSchema` extension mirrors this JSON Schema keyword when targeting OpenAPI versions where the keyword is not directly available, serializing it as `x-jsonschema-contentSchema`.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.0.4
+info:
+  title: My API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    EncodedPayload:
+      type: string
+      x-jsonschema-contentEncoding: base64
+      x-jsonschema-contentMediaType: application/json
+      x-jsonschema-contentSchema:
+        type: object
+        required:
+          - id
+        properties:
+          id:
+            type: string
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}

--- a/registries/_extension/x-jsonschema-contentSchema.md
+++ b/registries/_extension/x-jsonschema-contentSchema.md
@@ -9,9 +9,11 @@ layout: default
 ---
 
 {% capture summary %}
-JSON Schema defines the `contentSchema` keyword to describe the schema for decoded string content.
+JSON Schema 2019-09 introduced the [`contentSchema`](https://json-schema.org/draft/2019-09/json-schema-validation#rfc.section.8.5) annotation to describe the schema for decoded string content.
 
 The `x-jsonschema-contentSchema` extension mirrors this JSON Schema keyword when targeting OpenAPI versions where the keyword is not directly available, serializing it as `x-jsonschema-contentSchema`.
+
+Use this extension only with JSON Schema versions before 2019-09; 2019-09 and later define `contentSchema` directly.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 


### PR DESCRIPTION
Adds one OpenAPI extension registry page for a JSON Schema compatibility extension.

Evidence from OpenAPI.NET:
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs