### PR TITLE
docs: add x-jsonschema-maxContains extension page

### DIFF
--- a/registries/_extension/x-jsonschema-maxContains.md
+++ b/registries/_extension/x-jsonschema-maxContains.md
@@ -1,0 +1,43 @@
+---
+owner: mikekistler
+issue:
+description: The maximum number of array elements that may match contains, used when targeting OpenAPI versions that do not directly support maxContains.
+schema:
+  type: integer
+  minimum: 0
+objects: [ "Schema Object" ]
+layout: default
+---
+
+{% capture summary %}
+JSON Schema defines the `maxContains` keyword to set the maximum number of array elements that may match `contains`.
+
+The `x-jsonschema-maxContains` extension mirrors this JSON Schema keyword when targeting OpenAPI versions where the keyword is not directly available, serializing it as `x-jsonschema-maxContains`.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.0.4
+info:
+  title: My API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Roles:
+      type: array
+      items:
+        type: string
+      x-jsonschema-contains:
+        const: admin
+      x-jsonschema-maxContains: 1
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}

--- a/registries/_extension/x-jsonschema-maxContains.md
+++ b/registries/_extension/x-jsonschema-maxContains.md
@@ -10,9 +10,11 @@ layout: default
 ---
 
 {% capture summary %}
-JSON Schema defines the `maxContains` keyword to set the maximum number of array elements that may match `contains`.
+JSON Schema 2019-09 introduced the [`maxContains`](https://json-schema.org/draft/2019-09/json-schema-validation#rfc.section.6.4.4) keyword to set the maximum number of array elements that may match `contains`.
 
 The `x-jsonschema-maxContains` extension mirrors this JSON Schema keyword when targeting OpenAPI versions where the keyword is not directly available, serializing it as `x-jsonschema-maxContains`.
+
+Use this extension only with JSON Schema versions before 2019-09; 2019-09 and later define `maxContains` directly.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 

--- a/registries/_extension/x-jsonschema-maxContains.md
+++ b/registries/_extension/x-jsonschema-maxContains.md
@@ -1,5 +1,5 @@
 ---
-owner: mikekistler
+owner: baywet
 issue:
 description: The maximum number of array elements that may match contains, used when targeting OpenAPI versions that do not directly support maxContains.
 schema:


### PR DESCRIPTION
Adds one OpenAPI extension registry page for a JSON Schema compatibility extension.

Evidence from OpenAPI.NET:
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs