### PR TITLE
docs: add x-jsonschema-minContains extension page

### DIFF
--- a/registries/_extension/x-jsonschema-minContains.md
+++ b/registries/_extension/x-jsonschema-minContains.md
@@ -10,9 +10,11 @@ layout: default
 ---
 
 {% capture summary %}
-JSON Schema defines the `minContains` keyword to set the minimum number of array elements that must match `contains`.
+JSON Schema 2019-09 introduced the [`minContains`](https://json-schema.org/draft/2019-09/json-schema-validation#rfc.section.6.4.5) keyword to set the minimum number of array elements that must match `contains`.
 
 The `x-jsonschema-minContains` extension mirrors this JSON Schema keyword when targeting OpenAPI versions where the keyword is not directly available, serializing it as `x-jsonschema-minContains`.
+
+Use this extension only with JSON Schema versions before 2019-09; 2019-09 and later define `minContains` directly.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 

--- a/registries/_extension/x-jsonschema-minContains.md
+++ b/registries/_extension/x-jsonschema-minContains.md
@@ -1,5 +1,5 @@
 ---
-owner: mikekistler
+owner: baywet
 issue:
 description: The minimum number of array elements that must match contains, used when targeting OpenAPI versions that do not directly support minContains.
 schema:

--- a/registries/_extension/x-jsonschema-minContains.md
+++ b/registries/_extension/x-jsonschema-minContains.md
@@ -1,0 +1,43 @@
+---
+owner: mikekistler
+issue:
+description: The minimum number of array elements that must match contains, used when targeting OpenAPI versions that do not directly support minContains.
+schema:
+  type: integer
+  minimum: 0
+objects: [ "Schema Object" ]
+layout: default
+---
+
+{% capture summary %}
+JSON Schema defines the `minContains` keyword to set the minimum number of array elements that must match `contains`.
+
+The `x-jsonschema-minContains` extension mirrors this JSON Schema keyword when targeting OpenAPI versions where the keyword is not directly available, serializing it as `x-jsonschema-minContains`.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.0.4
+info:
+  title: My API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Roles:
+      type: array
+      items:
+        type: string
+      x-jsonschema-contains:
+        const: admin
+      x-jsonschema-minContains: 1
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}


### PR DESCRIPTION
Adds one OpenAPI extension registry page for a JSON Schema compatibility extension.

Evidence from OpenAPI.NET:
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs