### PR TITLE
docs: add x-jsonschema-then extension page

### DIFF
--- a/registries/_extension/x-jsonschema-then.md
+++ b/registries/_extension/x-jsonschema-then.md
@@ -1,5 +1,5 @@
 ---
-owner: mikekistler
+owner: baywet
 issue:
 description: The JSON Schema then conditional subschema, used with x-jsonschema-if when targeting OpenAPI versions that do not directly support it.
 schema:

--- a/registries/_extension/x-jsonschema-then.md
+++ b/registries/_extension/x-jsonschema-then.md
@@ -1,0 +1,54 @@
+---
+owner: mikekistler
+issue:
+description: The JSON Schema then conditional subschema, used with x-jsonschema-if when targeting OpenAPI versions that do not directly support it.
+schema:
+  $ref: "#/$defs/schemaObject"
+objects: [ "Schema Object" ]
+layout: default
+---
+
+{% capture summary %}
+The JSON Schema `then` keyword defines the subschema that applies when the `if` subschema matches.
+
+The `x-jsonschema-then` extension mirrors the JSON Schema `then` keyword when targeting OpenAPI versions where the keyword is not directly available. It is serialized as `x-jsonschema-then` so tools can preserve and process the conditional subschema alongside `x-jsonschema-if`.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.0.4
+info:
+  title: My API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Address:
+      type: object
+      properties:
+        country:
+          type: string
+        postalCode:
+          type: string
+      x-jsonschema-if:
+        properties:
+          country:
+            const: US
+        required:
+          - country
+      x-jsonschema-then:
+        properties:
+          postalCode:
+            pattern: "^[0-9]{5}$"
+        required:
+          - postalCode
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}

--- a/registries/_extension/x-jsonschema-then.md
+++ b/registries/_extension/x-jsonschema-then.md
@@ -9,9 +9,13 @@ layout: default
 ---
 
 {% capture summary %}
-The JSON Schema `then` keyword defines the subschema that applies when the `if` subschema matches.
+JSON Schema draft-07 introduced the [`then`](https://json-schema.org/draft-07/json-schema-validation#rfc.section.6.6.2) keyword to define the subschema that applies when the `if` subschema matches.
 
-The `x-jsonschema-then` extension mirrors the JSON Schema `then` keyword when targeting OpenAPI versions where the keyword is not directly available. It is serialized as `x-jsonschema-then` so tools can preserve and process the conditional subschema alongside `x-jsonschema-if`.
+The `x-jsonschema-then` extension mirrors this JSON Schema keyword when targeting OpenAPI versions where the keyword is not directly available, serializing it as `x-jsonschema-then`.
+
+Use this extension only with JSON Schema versions before draft-07; draft-07 and later define `then` directly.
+
+Although OpenAPI 3.0 used JSON Schema draft-07, it [prohibited this keyword](https://spec.openapis.org/oas/v3.0.4.html#json-schema-keywords), so use this extension with OpenAPI 3.0.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 


### PR DESCRIPTION
## Summary
- Adds one OpenAPI extension registry page for a JSON Schema compatibility extension.
- Documents that the keyword is serialized as `x-jsonschema-*` when targeting OpenAPI versions where the JSON Schema keyword is not directly available.

## OpenAPI.NET evidence
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Models/OpenApiSchema.cs exposes `PropertyNames`, `DependentSchemas`, `If`, `Then`, and `Else` schema members.
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs maps the corresponding OpenApiConstants extension names into those schema members during OpenAPI v3 deserialization.

## Validation
