### PR TITLE
docs: add x-jsonschema-dependentSchemas extension page

### DIFF
--- a/registries/_extension/x-jsonschema-dependentSchemas.md
+++ b/registries/_extension/x-jsonschema-dependentSchemas.md
@@ -11,9 +11,11 @@ layout: default
 ---
 
 {% capture summary %}
-The JSON Schema `dependentSchemas` keyword maps property names to schemas that apply when the corresponding property is present.
+JSON Schema 2019-09 introduced the [`dependentSchemas`](https://json-schema.org/draft/2019-09/json-schema-core#rfc.section.9.2.2.4) keyword to map property names to schemas that apply when the corresponding property is present.
 
-The `x-jsonschema-dependentSchemas` extension mirrors the JSON Schema `dependentSchemas` keyword when targeting OpenAPI versions where the keyword is not directly available. It is serialized as `x-jsonschema-dependentSchemas` so tools can preserve and process dependent schemas.
+The `x-jsonschema-dependentSchemas` extension mirrors this JSON Schema keyword when targeting OpenAPI versions where the keyword is not directly available, serializing it as `x-jsonschema-dependentSchemas`.
+
+Use this extension only with JSON Schema versions before 2019-09; 2019-09 and later define `dependentSchemas` directly.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 

--- a/registries/_extension/x-jsonschema-dependentSchemas.md
+++ b/registries/_extension/x-jsonschema-dependentSchemas.md
@@ -1,5 +1,5 @@
 ---
-owner: mikekistler
+owner: baywet
 issue:
 description: A map of schemas that apply when corresponding properties are present, used when targeting OpenAPI versions that do not directly support dependentSchemas.
 schema:

--- a/registries/_extension/x-jsonschema-dependentSchemas.md
+++ b/registries/_extension/x-jsonschema-dependentSchemas.md
@@ -1,0 +1,48 @@
+---
+owner: mikekistler
+issue:
+description: A map of schemas that apply when corresponding properties are present, used when targeting OpenAPI versions that do not directly support dependentSchemas.
+schema:
+  type: object
+  additionalProperties:
+    $ref: "#/$defs/schemaObject"
+objects: [ "Schema Object" ]
+layout: default
+---
+
+{% capture summary %}
+The JSON Schema `dependentSchemas` keyword maps property names to schemas that apply when the corresponding property is present.
+
+The `x-jsonschema-dependentSchemas` extension mirrors the JSON Schema `dependentSchemas` keyword when targeting OpenAPI versions where the keyword is not directly available. It is serialized as `x-jsonschema-dependentSchemas` so tools can preserve and process dependent schemas.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.0.4
+info:
+  title: My API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Payment:
+      type: object
+      properties:
+        creditCard:
+          type: string
+        billingAddress:
+          type: string
+      x-jsonschema-dependentSchemas:
+        creditCard:
+          required:
+            - billingAddress
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}


### PR DESCRIPTION
## Summary
- Adds one OpenAPI extension registry page for a JSON Schema compatibility extension.
- Documents that the keyword is serialized as `x-jsonschema-*` when targeting OpenAPI versions where the JSON Schema keyword is not directly available.

## OpenAPI.NET evidence
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Models/OpenApiSchema.cs exposes `PropertyNames`, `DependentSchemas`, `If`, `Then`, and `Else` schema members.
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs maps the corresponding OpenApiConstants extension names into those schema members during OpenAPI v3 deserialization.

## Validation
