### PR TITLE
docs: add x-jsonschema-propertyNames extension page

### DIFF
--- a/registries/_extension/x-jsonschema-propertyNames.md
+++ b/registries/_extension/x-jsonschema-propertyNames.md
@@ -1,5 +1,5 @@
 ---
-owner: mikekistler
+owner: baywet
 issue:
 description: A schema applied to property names in an object, used when targeting OpenAPI versions that do not directly support propertyNames.
 schema:

--- a/registries/_extension/x-jsonschema-propertyNames.md
+++ b/registries/_extension/x-jsonschema-propertyNames.md
@@ -9,9 +9,11 @@ layout: default
 ---
 
 {% capture summary %}
-The JSON Schema `propertyNames` keyword defines a schema that applies to property names in an object.
+JSON Schema draft-06 introduced the [`propertyNames`](https://json-schema.org/draft-06/json-schema-validation#rfc.section.6.22) keyword to define a schema that applies to property names in an object.
 
-The `x-jsonschema-propertyNames` extension mirrors the JSON Schema `propertyNames` keyword when targeting OpenAPI versions where the keyword is not directly available. It is serialized as `x-jsonschema-propertyNames` so tools can preserve and process property-name constraints.
+The `x-jsonschema-propertyNames` extension mirrors this JSON Schema keyword when targeting OpenAPI versions where the keyword is not directly available, serializing it as `x-jsonschema-propertyNames`.
+
+Use this extension only with JSON Schema versions before draft-06; draft-06 and later define `propertyNames` directly.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 

--- a/registries/_extension/x-jsonschema-propertyNames.md
+++ b/registries/_extension/x-jsonschema-propertyNames.md
@@ -1,0 +1,41 @@
+---
+owner: mikekistler
+issue:
+description: A schema applied to property names in an object, used when targeting OpenAPI versions that do not directly support propertyNames.
+schema:
+  $ref: "#/$defs/schemaObject"
+objects: [ "Schema Object" ]
+layout: default
+---
+
+{% capture summary %}
+The JSON Schema `propertyNames` keyword defines a schema that applies to property names in an object.
+
+The `x-jsonschema-propertyNames` extension mirrors the JSON Schema `propertyNames` keyword when targeting OpenAPI versions where the keyword is not directly available. It is serialized as `x-jsonschema-propertyNames` so tools can preserve and process property-name constraints.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.0.4
+info:
+  title: My API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Metadata:
+      type: object
+      additionalProperties:
+        type: string
+      x-jsonschema-propertyNames:
+        pattern: "^[a-z_]+$"
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}


### PR DESCRIPTION
## Summary
- Adds one OpenAPI extension registry page for a JSON Schema compatibility extension.
- Documents that the keyword is serialized as `x-jsonschema-*` when targeting OpenAPI versions where the JSON Schema keyword is not directly available.

## OpenAPI.NET evidence
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Models/OpenApiSchema.cs exposes `PropertyNames`, `DependentSchemas`, `If`, `Then`, and `Else` schema members.
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs maps the corresponding OpenApiConstants extension names into those schema members during OpenAPI v3 deserialization.

## Validation
