### PR TITLE
docs: add x-oai-serializedValue extension page

### DIFF
--- a/registries/_extension/x-oai-serializedValue.md
+++ b/registries/_extension/x-oai-serializedValue.md
@@ -1,5 +1,5 @@
 ---
-owner: mikekistler
+owner: baywet
 issue:
 description: A serialized example value for an Example Object, used when targeting OpenAPI versions prior to 3.2.
 schema:

--- a/registries/_extension/x-oai-serializedValue.md
+++ b/registries/_extension/x-oai-serializedValue.md
@@ -9,9 +9,11 @@ layout: default
 ---
 
 {% capture summary %}
-OpenAPI 3.2 introduced the `serializedValue` field on Example Objects to provide already-serialized example data.
+OpenAPI 3.2 introduced the [`serializedValue`](https://spec.openapis.org/oas/v3.2.0.html#example-serialized-value) field on Example Objects to provide already-serialized example data.
 
 The `x-oai-serializedValue` extension brings this same capability to OpenAPI versions prior to 3.2, allowing you to provide already-serialized example data on an Example Object.
+
+Use this extension only with OpenAPI versions before 3.2; OpenAPI 3.2 and later define `serializedValue` directly.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 

--- a/registries/_extension/x-oai-serializedValue.md
+++ b/registries/_extension/x-oai-serializedValue.md
@@ -1,0 +1,38 @@
+---
+owner: mikekistler
+issue:
+description: A serialized example value for an Example Object, used when targeting OpenAPI versions prior to 3.2.
+schema:
+  type: string
+objects: [ "Example Object" ]
+layout: default
+---
+
+{% capture summary %}
+OpenAPI 3.2 introduced the `serializedValue` field on Example Objects to provide already-serialized example data.
+
+The `x-oai-serializedValue` extension brings this same capability to OpenAPI versions prior to 3.2, allowing you to provide already-serialized example data on an Example Object.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.1.0
+info:
+  title: My API
+  version: 1.0.0
+paths: {}
+components:
+  examples:
+    csvExample:
+      summary: A CSV example
+      x-oai-serializedValue: "id,name\n1,Ada"
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}


### PR DESCRIPTION
Documents the `x-oai-serializedValue` extension used by OpenAPI.NET for OpenAPI versions prior to 3.2.

Source evidence:
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Models/OpenApiExample.cs
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Reader/V3/OpenApiExampleDeserializer.cs
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Reader/V31/OpenApiExampleDeserializer.cs