### PR TITLE
docs: add x-oai-deviceAuthorization extension page

### DIFF
--- a/registries/_extension/x-oai-deviceAuthorization.md
+++ b/registries/_extension/x-oai-deviceAuthorization.md
@@ -1,0 +1,44 @@
+---
+owner: mikekistler
+issue:
+description: A device authorization OAuth2 flow, used when targeting OpenAPI versions prior to 3.2.
+schema:
+  type: object
+objects: [ "OAuth Flows Object" ]
+layout: default
+---
+
+{% capture summary %}
+OpenAPI 3.2 introduced the `deviceAuthorization` field on OAuth Flows Objects to define a device authorization OAuth2 flow.
+
+The `x-oai-deviceAuthorization` extension brings this same capability to OpenAPI versions prior to 3.2, allowing you to define a device authorization OAuth2 flow.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.1.0
+info:
+  title: My API
+  version: 1.0.0
+paths: {}
+components:
+  securitySchemes:
+    oauth2:
+      type: oauth2
+      flows:
+        x-oai-deviceAuthorization:
+          authorizationUrl: https://auth.example.com/authorize
+          tokenUrl: https://auth.example.com/token
+          x-oai-deviceAuthorizationUrl: https://auth.example.com/device
+          scopes:
+            read: Read access
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}

--- a/registries/_extension/x-oai-deviceAuthorization.md
+++ b/registries/_extension/x-oai-deviceAuthorization.md
@@ -3,7 +3,7 @@ owner: baywet
 issue:
 description: A device authorization OAuth2 flow, used when targeting OpenAPI versions prior to 3.2.
 schema:
-  type: object
+  $ref: "#/$defs/oauthFlowObject"
 objects: [ "OAuth Flows Object" ]
 layout: default
 ---

--- a/registries/_extension/x-oai-deviceAuthorization.md
+++ b/registries/_extension/x-oai-deviceAuthorization.md
@@ -9,9 +9,11 @@ layout: default
 ---
 
 {% capture summary %}
-OpenAPI 3.2 introduced the `deviceAuthorization` field on OAuth Flows Objects to define a device authorization OAuth2 flow.
+OpenAPI 3.2 introduced the [`deviceAuthorization`](https://spec.openapis.org/oas/v3.2.0.html#oauth-flows-device-authorization) field on OAuth Flows Objects to define a device authorization OAuth2 flow.
 
 The `x-oai-deviceAuthorization` extension brings this same capability to OpenAPI versions prior to 3.2, allowing you to define a device authorization OAuth2 flow.
+
+Use this extension only with OpenAPI versions before 3.2; OpenAPI 3.2 and later define `deviceAuthorization` directly.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 

--- a/registries/_extension/x-oai-deviceAuthorization.md
+++ b/registries/_extension/x-oai-deviceAuthorization.md
@@ -1,5 +1,5 @@
 ---
-owner: mikekistler
+owner: baywet
 issue:
 description: A device authorization OAuth2 flow, used when targeting OpenAPI versions prior to 3.2.
 schema:


### PR DESCRIPTION
Documents the `x-oai-deviceAuthorization` extension used by OpenAPI.NET for OpenAPI versions prior to 3.2.

Source evidence:
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Reader/V3/OpenApiOAuthFlowsDeserializer.cs
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Reader/V31/OpenApiOAuthFlowsDeserializer.cs