### PR TITLE
docs: add x-oai-$self extension page

### DIFF
--- a/registries/_extension/x-oai-$self.md
+++ b/registries/_extension/x-oai-$self.md
@@ -1,0 +1,35 @@
+---
+owner: mikekistler
+issue:
+description: The canonical absolute URI for an OpenAPI document, used when targeting OpenAPI versions prior to 3.2.
+schema:
+  type: string
+  format: uri
+objects: [ "OpenAPI Object" ]
+layout: default
+---
+
+{% capture summary %}
+OpenAPI 3.2 introduced the `self` field on OpenAPI Objects to identify the canonical absolute URI for an OpenAPI document.
+
+The `x-oai-$self` extension brings this same capability to OpenAPI versions prior to 3.2, allowing you to identify the canonical absolute URI for an OpenAPI document.
+
+It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+
+Used by: (informational)
+
+* [Microsoft.OpenApi](https://github.com/microsoft/OpenAPI.NET) (.NET OpenAPI library)
+{% endcapture %}
+
+{% capture example %}
+```yaml
+openapi: 3.1.0
+info:
+  title: My API
+  version: 1.0.0
+x-oai-$self: https://example.org/api/openapi.json
+paths: {}
+```
+{% endcapture %}
+
+{% include extension-entry.md summary=summary example=example %}

--- a/registries/_extension/x-oai-$self.md
+++ b/registries/_extension/x-oai-$self.md
@@ -1,5 +1,5 @@
 ---
-owner: mikekistler
+owner: baywet
 issue:
 description: The canonical absolute URI for an OpenAPI document, used when targeting OpenAPI versions prior to 3.2.
 schema:

--- a/registries/_extension/x-oai-$self.md
+++ b/registries/_extension/x-oai-$self.md
@@ -10,9 +10,11 @@ layout: default
 ---
 
 {% capture summary %}
-OpenAPI 3.2 introduced the `self` field on OpenAPI Objects to identify the canonical absolute URI for an OpenAPI document.
+OpenAPI 3.2 introduced the [`$self`](https://spec.openapis.org/oas/v3.2.0.html#oas-self) field on OpenAPI Objects to identify the canonical absolute URI for an OpenAPI document.
 
 The `x-oai-$self` extension brings this same capability to OpenAPI versions prior to 3.2, allowing you to identify the canonical absolute URI for an OpenAPI document.
+
+Use this extension only with OpenAPI versions before 3.2; OpenAPI 3.2 and later define `$self` directly.
 
 It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 


### PR DESCRIPTION
Documents the `x-oai-$self` extension used by OpenAPI.NET for OpenAPI versions prior to 3.2.

Source evidence:
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Reader/V3/OpenApiDocumentDeserializer.cs
- https://github.com/microsoft/OpenAPI.NET/blob/main/src/Microsoft.OpenApi/Reader/V31/OpenApiDocumentDeserializer.cs