### PR TITLE
docs: adds guidance for namespace vs extension and registries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,25 @@ fork this repository in GitHub.
 Make a local clone of your fork and check out the
 `main` branch.
 
+### Guidelines for namespaces and extensions
+
+Try to re-use existing extensions when possible to improve interoperability.
+
+Extensions that belong to a namespace may be defined in the OpenAPI extensions registry or in an external registry administered by the namespace owner.
+
+Using the OpenAPI extensions registry provides the following benefits:
+
+- No setup required.
+- OpenAPI contributors will inform the design of the extension.
+- Better visibility.
+
+Using an external registry provides the following benefits:
+
+- No review from OpenAPI contributors required.
+- Control over branding, page layout and more.
+
+In either case, if you are using extensions with namespaces, it's a good practice to register the namespace to avoid potential future collisions.
+
 ### Add a New Extension Namespace Registry Entry
 
 Working in the `main` branch,
@@ -79,6 +98,7 @@ owner: <<Your-GitHub-username>>
 issue:
 description: <<Briefly describe your namespace>>
 layout: default
+registry: <<the url to your external registry OR ../extension/index.html>>
 ---
 
 {% capture summary %}

--- a/registries/_namespace/fdx.md
+++ b/registries/_namespace/fdx.md
@@ -3,6 +3,7 @@ owner: DavidBiesack
 issue:
 description: Extensions created and used by [Financial Data Exchange (FDX)](https://financialdataexchange.org)
 layout: default
+registry: ../extension/index.html
 ---
 
 {% capture summary %}

--- a/registries/_namespace/ms.md
+++ b/registries/_namespace/ms.md
@@ -1,8 +1,9 @@
 ---
 owner: DarrelMiller
 issue: 
-description: Extensions [created and used by Microsoft](https://github.com/microsoft/OpenAPI/blob/main/extensions/index.md)
+description: Extensions created and used by Microsoft
 layout: default
+registry: https://github.com/microsoft/OpenAPI/blob/main/extensions/index.md
 ---
 
 {% capture summary %}

--- a/registries/_namespace/oai.md
+++ b/registries/_namespace/oai.md
@@ -3,6 +3,7 @@ owner: DarrelMiller
 issue: 
 description: Reserved for uses defined by the OAI
 layout: default
+registry: ../extension/index.html
 ---
 
 {% capture summary %}

--- a/registries/_namespace/oas-draft.md
+++ b/registries/_namespace/oas-draft.md
@@ -3,6 +3,7 @@ owner: DarrelMiller
 issue: 
 description: Extensions created by OAI to indicate proposed changes to the OAS specification
 layout: default
+registry: ../extension/index.html
 ---
 
 {% capture summary %}

--- a/registries/_namespace/oas.md
+++ b/registries/_namespace/oas.md
@@ -3,6 +3,7 @@ owner: DarrelMiller
 issue: 
 description: Reserved for uses defined by the OAI
 layout: default
+registry: ../extension/index.html
 ---
 
 {% capture summary %}

--- a/registries/_namespace/sap.md
+++ b/registries/_namespace/sap.md
@@ -3,6 +3,7 @@ owner: ralfhandl, pavelkornev
 issue: 
 description: Extensions created and used by SAP
 layout: default
+registry: https://github.com/SAP/openapi-specification
 ---
 
 {% capture summary %}

--- a/registries/_namespace/scalar.md
+++ b/registries/_namespace/scalar.md
@@ -3,6 +3,7 @@ owner: marclave, hanspagel, amritk
 issue:
 description: Extensions created and used by Scalar
 layout: default
+registry: https://guides.scalar.com/scalar/scalar-api-references/openapi#openapi-specification__custom-specification-extensions
 ---
 
 {% capture summary %}

--- a/registry/extension.md
+++ b/registry/extension.md
@@ -1,5 +1,5 @@
 ---
-# title: Extensions Registry
+title: Extensions Registry
 layout: default
 permalink: /registry/extension/index.html
 parent: Registries

--- a/registry/namespace.md
+++ b/registry/namespace.md
@@ -20,7 +20,7 @@ to contribute or discuss a registry value.
 
 ## Values
 
-|Value|Prefix|Description|Issue|
+|Value|Prefix|Description|Registry|
 |---|---|---|---|
-{% for value in site.namespace %}| <a href="./{{ value.slug }}.html">{{ value.slug }}</a> | x-{{ value.slug }}-|{{ value.description }} | {% if value.issue %}<a href="https://github.com/OAI/OpenAPI-Specification/issues/{{ value.issue }}">#{{ value.issue }}</a>{% endif %} |
+{% for value in site.namespace %}| <a href="./{{ value.slug }}.html">{{ value.slug }}</a> | x-{{ value.slug }}-|{{ value.description }} | {% if value.registry %}<a href="{{ value.registry }}">Link</a>{% endif %} |
 {% endfor %}


### PR DESCRIPTION
fixes #108
this pull request:
- adds missing guidance of when to use external vs the public registry
- fixes a missing title for the extension page to be in the left nav
- reworks the namespace table slightly to include a link to all the registries