### PR TITLE
Update date-time formats to RFC 9557

### DIFF
--- a/registries/_format/date-time-local.md
+++ b/registries/_format/date-time-local.md
@@ -9,7 +9,7 @@ source: https://www.rfc-editor.org/info/rfc9557/#section-4.1
 ---
 
 {% capture summary %}
-The `{{page.slug}}` format represents a RFC9557 date-time without timezone - [RFC9557](https://www.rfc-editor.org/info/rfc9557/#section-4.1).
+The `{{page.slug}}` format represents a date-time without timezone - [RFC9557](https://www.rfc-editor.org/info/rfc9557/#section-4.1).
 {% endcapture %}
 
 {% include format-entry.md summary=summary %}

--- a/registries/_format/date-time-local.md
+++ b/registries/_format/date-time-local.md
@@ -1,15 +1,15 @@
 ---
 owner: ya7010
 issue: 4759
-description: RFC3339 date-time without the timezone component
+description: date-time without the timezone component - [RFC9557](https://www.rfc-editor.org/info/rfc9557/#section-4.1)
 base_type: string
 layout: default
-source_label: RFC 3339
-source: https://www.rfc-editor.org/rfc/rfc3339#section-5.6
+source_label: RFC9557
+source: https://www.rfc-editor.org/info/rfc9557/#section-4.1
 ---
 
 {% capture summary %}
-The `{{page.slug}}` format represents a RFC3339 date-time without timezone.
+The `{{page.slug}}` format represents a RFC9557 date-time without timezone - [RFC9557](https://www.rfc-editor.org/info/rfc9557/#section-4.1).
 {% endcapture %}
 
 {% include format-entry.md summary=summary %}

--- a/registries/_format/date-time.md
+++ b/registries/_format/date-time.md
@@ -1,15 +1,15 @@
 ---
 owner: DarrelMiller
 issue: 
-description: date and time as defined by date-time - [RFC3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6)
+description: date and time as defined by date-time - [RFC9557](https://www.rfc-editor.org/info/rfc9557/#section-4.1)
 base_type: string
 layout: default
-source_label: JSON Schema
-source: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-dates-times-and-duration
+source_label: RFC9557
+source: https://www.rfc-editor.org/info/rfc9557/#section-4.1
 ---
 
 {% capture summary %}
-The `{{page.slug}}` format represents a date and time as defined by date-time - [RFC3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6). This format entry is to ensure future versions of OpenAPI maintain compatibility with [OpenAPI 3.0.x](https://spec.openapis.org/oas/v3.0.0).
+The `{{page.slug}}` format represents a date and time as defined by date-time - [RFC9557](https://www.rfc-editor.org/info/rfc9557/#section-4.1). This format entry is to ensure future versions of OpenAPI maintain compatibility with [OpenAPI 3.0.x](https://spec.openapis.org/oas/v3.0.0).
 {% endcapture %}
 
 {% include format-entry.md summary=summary %}

--- a/registries/_format/date.md
+++ b/registries/_format/date.md
@@ -1,15 +1,15 @@
 ---
 owner: DarrelMiller
 issue: 
-description: date as defined by full-date - [RFC3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6)
+description: date as defined by full-date - [RFC9557](https://www.rfc-editor.org/info/rfc9557/#section-4.1)
 base_type: string
 layout: default
-source_label: JSON Schema
-source: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-dates-times-and-duration
+source_label: RFC9557
+source: https://www.rfc-editor.org/info/rfc9557/#section-4.1
 ---
 
 {% capture summary %}
-The `{{page.slug}}` format represents a date as defined by full-date - [RFC3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6). This format entry is to ensure future versions of OpenAPI maintain compatibility with [OpenAPI 3.0.x](https://spec.openapis.org/oas/v3.0.0).
+The `{{page.slug}}` format represents a date as defined by full-date - [RFC9557](https://www.rfc-editor.org/info/rfc9557/#section-4.1). This format entry is to ensure future versions of OpenAPI maintain compatibility with [OpenAPI 3.0.x](https://spec.openapis.org/oas/v3.0.0).
 {% endcapture %}
 
 {% include format-entry.md summary=summary %}

--- a/registries/_format/duration.md
+++ b/registries/_format/duration.md
@@ -1,15 +1,15 @@
 ---
 owner: baywet
 issue: 
-description: duration as defined by duration - RFC3339
+description: duration as defined by duration - [RFC9557](https://www.rfc-editor.org/info/rfc9557/#section-4.1)
 base_type: string
 layout: default
-source_label: JSON Schema
-source: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-dates-times-and-duration
+source_label: RFC9557
+source: https://www.rfc-editor.org/info/rfc9557/#section-4.1
 ---
 
 {% capture summary %}
-The `{{page.slug}}` format represents a duration as defined by duration - [RFC3339](https://www.rfc-editor.org/rfc/rfc3339.html#appendix-A).
+The `{{page.slug}}` format represents a duration as defined by duration - [RFC9557](https://www.rfc-editor.org/info/rfc9557/#section-4.1).
 {% endcapture %}
 
 {% include format-entry.md summary=summary %}

--- a/registries/_format/time-local.md
+++ b/registries/_format/time-local.md
@@ -1,15 +1,15 @@
 ---
 owner: ya7010
 issue: 4759
-description: RFC3339 time without the timezone component
+description: time without the timezone component - [RFC9557](https://www.rfc-editor.org/info/rfc9557/#section-4.1)
 base_type: string
 layout: default
-source_label: RFC 3339
-source: https://www.rfc-editor.org/rfc/rfc3339#section-5.6
+source_label: RFC9557
+source: https://www.rfc-editor.org/info/rfc9557/#section-4.1
 ---
 
 {% capture summary %}
-The `{{page.slug}}` format represents a RFC3339 time without timezone.
+The `{{page.slug}}` format represents a time without timezone - [RFC9557](https://www.rfc-editor.org/info/rfc9557/#section-4.1).
 {% endcapture %}
 
 {% include format-entry.md summary=summary %}

--- a/registries/_format/time.md
+++ b/registries/_format/time.md
@@ -1,15 +1,15 @@
 ---
 owner: baywet
 issue: 
-description: time as defined by full-time - RFC3339
+description: time as defined by full-time - [RFC9557](https://www.rfc-editor.org/info/rfc9557/#section-4.1)
 base_type: string
 layout: default
-source_label: JSON Schema
-source: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-dates-times-and-duration
+source_label: RFC9557
+source: https://www.rfc-editor.org/info/rfc9557/#section-4.1
 ---
 
 {% capture summary %}
-The `{{page.slug}}` format represents a time as defined by full-time - [RFC3339](https://www.rfc-editor.org/rfc/rfc3339.html#section-5.6).
+The `{{page.slug}}` format represents a time as defined by full-time - [RFC9557](https://www.rfc-editor.org/info/rfc9557/#section-4.1).
 {% endcapture %}
 
 {% include format-entry.md summary=summary %}


### PR DESCRIPTION
RFC 3339 is updated by RFC 9557. By specifying all formats asRFC 9557, values in RFC 9557 format are now also allowed, not just values RFC 3339 format.

All entries also use consistent formatting and naming now,including which URL to link to and what the `source_label` is.